### PR TITLE
Grabs a snapshot of values from the main thread

### DIFF
--- a/framework/Source/iOS/GPUImageView.m
+++ b/framework/Source/iOS/GPUImageView.m
@@ -232,15 +232,19 @@
 
 - (void)recalculateViewGeometry;
 {
+    __block CGRect currentBounds;
+    
+    runOnMainQueueWithoutDeadlocking(^{
+        currentBounds = self.bounds;
+    });
+        
     runSynchronouslyOnVideoProcessingQueue(^{
         CGFloat heightScaling, widthScaling;
-        
-        CGSize currentViewSize = self.bounds.size;
-        
+
         //    CGFloat imageAspectRatio = inputImageSize.width / inputImageSize.height;
         //    CGFloat viewAspectRatio = currentViewSize.width / currentViewSize.height;
-        
-        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, self.bounds);
+    
+        CGRect insetRect = AVMakeRectWithAspectRatioInsideRect(inputImageSize, currentBounds);
         
         switch(_fillMode)
         {
@@ -251,14 +255,14 @@
             }; break;
             case kGPUImageFillModePreserveAspectRatio:
             {
-                widthScaling = insetRect.size.width / currentViewSize.width;
-                heightScaling = insetRect.size.height / currentViewSize.height;
+                widthScaling = insetRect.size.width / currentBounds.size.width;
+                heightScaling = insetRect.size.height / currentBounds.size.height;
             }; break;
             case kGPUImageFillModePreserveAspectRatioAndFill:
             {
-                //            CGFloat widthHolder = insetRect.size.width / currentViewSize.width;
-                widthScaling = currentViewSize.height / insetRect.size.height;
-                heightScaling = currentViewSize.width / insetRect.size.width;
+                //            CGFloat widthHolder = insetRect.size.width / currentBounds.size.width;
+                widthScaling = currentBounds.size.height / insetRect.size.height;
+                heightScaling = currentBounds.size.width / insetRect.size.width;
             }; break;
         }
         


### PR DESCRIPTION
Otherwise, reading any UIKit values like `.bounds` will give a warning:
Main Thread Checker: UI API called on a background thread: -[UIView bounds]

Taking out debug code